### PR TITLE
Update pandas testing imports

### DIFF
--- a/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_capacity.py
+++ b/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_capacity.py
@@ -9,8 +9,7 @@ from pandas import (
     datetime,
     concat
 )
-from pandas.util.testing import (assert_frame_equal,
-                                 assert_series_equal)
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pyfolio.capacity import (days_to_liquidate_positions,
                               get_max_days_to_liquidate_by_ticker,

--- a/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_perf_attrib.py
+++ b/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_perf_attrib.py
@@ -152,11 +152,11 @@ class PerfAttribTestCase(unittest.TestCase):
                                                               factor_returns,
                                                               factor_loadings)
 
-        pd.util.testing.assert_frame_equal(expected_perf_attrib_output,
-                                           perf_attrib_output)
+        pd.testing.assert_frame_equal(expected_perf_attrib_output,
+                                      perf_attrib_output)
 
-        pd.util.testing.assert_frame_equal(expected_exposures_portfolio,
-                                           exposures_portfolio)
+        pd.testing.assert_frame_equal(expected_exposures_portfolio,
+                                      exposures_portfolio)
 
         # test long and short positions
         positions = pd.DataFrame(index=dts,
@@ -190,11 +190,11 @@ class PerfAttribTestCase(unittest.TestCase):
                   'risk_factor2': [0.0, 0.0]}
         )
 
-        pd.util.testing.assert_frame_equal(expected_perf_attrib_output,
-                                           perf_attrib_output)
+        pd.testing.assert_frame_equal(expected_perf_attrib_output,
+                                      perf_attrib_output)
 
-        pd.util.testing.assert_frame_equal(expected_exposures_portfolio,
-                                           exposures_portfolio)
+        pd.testing.assert_frame_equal(expected_exposures_portfolio,
+                                      exposures_portfolio)
 
         perf_attrib_summary, exposures_summary = create_perf_attrib_stats(
             perf_attrib_output, exposures_portfolio
@@ -206,7 +206,7 @@ class PerfAttribTestCase(unittest.TestCase):
         self.assertEqual(perf_attrib_summary['Cumulative Specific Return'],
                          perf_attrib_summary['Total Returns'])
 
-        pd.util.testing.assert_frame_equal(
+        pd.testing.assert_frame_equal(
             exposures_summary,
             pd.DataFrame(0.0, index=['risk_factor1', 'risk_factor2'],
                          columns=['Average Risk Factor Exposure',
@@ -257,16 +257,16 @@ class PerfAttribTestCase(unittest.TestCase):
 
         # since all returns are factor returns, common returns should be
         # equivalent to total returns, and specific returns should be 0
-        pd.util.testing.assert_series_equal(returns,
-                                            common_returns,
-                                            check_names=False)
+        pd.testing.assert_series_equal(returns,
+                                       common_returns,
+                                       check_names=False)
 
         self.assertTrue(np.isclose(specific_returns, 0).all())
 
         # specific and common returns combined should equal total returns
-        pd.util.testing.assert_series_equal(returns,
-                                            combined_returns,
-                                            check_names=False)
+        pd.testing.assert_series_equal(returns,
+                                       combined_returns,
+                                       check_names=False)
 
         # check that residuals + intercepts = specific returns
         self.assertTrue(np.isclose((residuals + intercepts), 0).all())
@@ -276,13 +276,13 @@ class PerfAttribTestCase(unittest.TestCase):
             factor_returns, axis='rows'
         ).sum(axis='columns')
 
-        pd.util.testing.assert_series_equal(expected_common_returns,
-                                            common_returns,
-                                            check_names=False)
+        pd.testing.assert_series_equal(expected_common_returns,
+                                       common_returns,
+                                       check_names=False)
 
         # since factor loadings are ones, portfolio risk exposures
         # should be ones
-        pd.util.testing.assert_frame_equal(
+        pd.testing.assert_frame_equal(
             risk_exposures_portfolio,
             pd.DataFrame(np.ones_like(risk_exposures_portfolio),
                          index=risk_exposures_portfolio.index,
@@ -317,7 +317,7 @@ class PerfAttribTestCase(unittest.TestCase):
         avg_factor_exposure = risk_exposures_portfolio.mean().rename(
             'Average Risk Factor Exposure'
         )
-        pd.util.testing.assert_series_equal(
+        pd.testing.assert_series_equal(
             avg_factor_exposure,
             exposures_summary['Average Risk Factor Exposure']
         )
@@ -329,7 +329,7 @@ class PerfAttribTestCase(unittest.TestCase):
             index=risk_exposures_portfolio.columns
         )
 
-        pd.util.testing.assert_series_equal(
+        pd.testing.assert_series_equal(
             cumulative_returns_by_factor,
             exposures_summary['Cumulative Return']
         )
@@ -341,7 +341,7 @@ class PerfAttribTestCase(unittest.TestCase):
             index=risk_exposures_portfolio.columns
         )
 
-        pd.util.testing.assert_series_equal(
+        pd.testing.assert_series_equal(
             annualized_returns_by_factor,
             exposures_summary['Annualized Return']
         )
@@ -479,14 +479,14 @@ class PerfAttribTestCase(unittest.TestCase):
 
         expected_returns = pd.Series([0.1, 0.21, 0.331],
                                      index=returns.index)
-        pd.util.testing.assert_series_equal(
+        pd.testing.assert_series_equal(
             expected_returns,
             _cumulative_returns_less_costs(returns, None)
         )
 
         expected_returns = pd.Series([0.099000, 0.207801, 0.327373],
                                      index=returns.index)
-        pd.util.testing.assert_series_equal(
+        pd.testing.assert_series_equal(
             expected_returns,
             _cumulative_returns_less_costs(returns, cost)
         )

--- a/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_pos.py
+++ b/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_pos.py
@@ -11,7 +11,7 @@ from pandas import (
     Timestamp,
     read_csv
 )
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from numpy import (
     arange,

--- a/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_round_trips.py
+++ b/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_round_trips.py
@@ -10,7 +10,7 @@ from pandas import (
     Timedelta,
     read_csv
 )
-from pandas.util.testing import (assert_frame_equal)
+from pandas.testing import assert_frame_equal
 
 import os
 import gzip

--- a/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_timeseries.py
+++ b/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_timeseries.py
@@ -4,7 +4,7 @@ import os
 from unittest import TestCase
 from nose_parameterized import parameterized
 from numpy.testing import assert_allclose, assert_almost_equal
-from pandas.util.testing import assert_series_equal
+from pandas.testing import assert_series_equal
 
 import numpy as np
 import pandas as pd

--- a/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_txn.py
+++ b/fingpt/FinGPT_Others/FinGPT_Trading/chatgpt-trading-v2/pyfolio/tests/test_txn.py
@@ -5,7 +5,7 @@ from pandas import (
     DataFrame,
     date_range
 )
-from pandas.util.testing import (assert_series_equal)
+from pandas.testing import assert_series_equal
 
 from pyfolio.txn import (get_turnover,
                          adjust_returns_for_slippage)


### PR DESCRIPTION
## Summary
- update pandas.util.testing references to pandas.testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684293af494c832599dff1c56dbfb4dd