### PR TITLE
Fix minor typos in data utils comment

### DIFF
--- a/fingpt/FinGPT_RAG/instruct-FinGPT/training/utils/data/data_utils.py
+++ b/fingpt/FinGPT_RAG/instruct-FinGPT/training/utils/data/data_utils.py
@@ -364,7 +364,7 @@ class DataCollatorRLHF:
                                    padding_value=0,
                                    batch_first=True)
 
-        ### make sure the final ouput is a seqence of 2**?
+        ### make sure the final output is a sequence of 2**?
         length = prompt.size()[-1]
         pad_length = self.max_token_len - length
         if pad_length > 0:


### PR DESCRIPTION
## Summary
- correct typos in a comment in `data_utils.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684293ad73ac8325a8bb7b85e5c08e0b