### PR TITLE
Fix margin regex

### DIFF
--- a/fingpt/FinGPT_Forecaster/utils.py
+++ b/fingpt/FinGPT_Forecaster/utils.py
@@ -96,8 +96,8 @@ def parse_answer(answer):
             
     match_res = re.search(r'(\d)-(\d)%', pred)
     if not match_res:
-        match_res = re.search(r'(?:more than )?(\d)+?%', pred)    
-        
+        match_res = re.search(r'(?:more than )?(\d+)%', pred)
+
     pred_margin = pred_bin * (int(match_res.group(1)) + 0.5) if match_res else 0.
         
     return {


### PR DESCRIPTION
## Summary
- fix regex in `parse_answer` so multi-digit percentages are parsed correctly

## Testing
- `python -m py_compile fingpt/FinGPT_Forecaster/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684293ad618c8325bd783e3dd801b16f