### PR TITLE
Add FinGPT YouTube comment analysis and opinion rollup module

### DIFF
--- a/fingpt/FinGPT_YouTubeAnalysis/.env.example
+++ b/fingpt/FinGPT_YouTubeAnalysis/.env.example
@@ -1,0 +1,1 @@
+YOUTUBE_API_KEY=

--- a/fingpt/FinGPT_YouTubeAnalysis/__init__.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/__init__.py
@@ -1,0 +1,10 @@
+"""
+FinGPT YouTube Comment Analysis and Opinion Rollup.
+
+Provides tools for scraping, classifying, and aggregating
+YouTube comment sentiment across demographic dimensions.
+"""
+from .pipeline import run_pipeline
+from .report import generate_report
+
+__all__ = ["run_pipeline", "generate_report"]

--- a/fingpt/FinGPT_YouTubeAnalysis/app.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/app.py
@@ -1,0 +1,121 @@
+import os
+import logging
+
+import gradio as gr
+import pandas as pd
+from dotenv import load_dotenv
+
+from .pipeline import run_pipeline
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def predict(
+    video_url: str,
+    max_comments: int,
+    analyze_political: bool,
+    analyze_socioeconomic: bool,
+    analyze_gender: bool,
+    analyze_emotion: bool,
+    output_format: str,
+    include_bias_audit: bool,
+) -> tuple[str, pd.DataFrame]:
+    """
+    Gradio-facing wrapper around run_pipeline.
+    Collects enabled dimensions from the checkbox inputs.
+    Returns (report_string, annotated_dataframe).
+    """
+    if not video_url or not video_url.strip():
+        raise gr.Error("Please enter a YouTube video URL.")
+
+    dimensions = []
+    if analyze_political:
+        dimensions.append("political")
+    if analyze_socioeconomic:
+        dimensions.append("socioeconomic")
+    if analyze_gender:
+        dimensions.append("gender")
+    if analyze_emotion:
+        dimensions.append("emotion")
+
+    if not dimensions:
+        raise gr.Error("Please select at least one analysis dimension.")
+
+    try:
+        report, df = run_pipeline(
+            url=video_url.strip(),
+            max_comments=int(max_comments),
+            dimensions=dimensions,
+            output_format=output_format,
+            prefer_api=bool(os.getenv("YOUTUBE_API_KEY")),
+            include_bias_audit=include_bias_audit,
+        )
+    except ValueError as e:
+        raise gr.Error(str(e))
+    except Exception as e:
+        logger.exception("Pipeline error for URL %s", video_url)
+        raise gr.Error(f"Analysis failed: {e}")
+
+    return report, df
+
+
+demo = gr.Interface(
+    predict,
+    inputs=[
+        gr.Textbox(
+            label="YouTube Video URL",
+            placeholder="https://www.youtube.com/watch?v=...",
+            info="Paste any YouTube video URL. API key optional — yt-dlp is used as fallback.",
+        ),
+        gr.Slider(
+            minimum=50,
+            maximum=2000,
+            value=500,
+            step=50,
+            label="Max Comments to Analyze",
+            info="More comments = more accurate results but slower processing.",
+        ),
+        gr.Checkbox(label="Analyze Political Lean", value=True),
+        gr.Checkbox(label="Analyze Socioeconomic Proxy", value=True),
+        gr.Checkbox(label="Analyze Gender Proxy", value=True),
+        gr.Checkbox(label="Analyze Emotion", value=True),
+        gr.Dropdown(
+            choices=["markdown", "json", "csv"],
+            value="markdown",
+            label="Output Format",
+        ),
+        gr.Checkbox(
+            label="Include Bias Audit (HHI)",
+            value=True,
+            info="Herfindahl-Hirschman Index measures opinion concentration per dimension.",
+        ),
+    ],
+    outputs=[
+        gr.Textbox(label="Analysis Report", lines=40),
+        gr.Dataframe(label="Annotated Comments", wrap=True),
+    ],
+    title="FinGPT YouTube Comment Analyzer",
+    description="""
+Analyze YouTube video comments across multiple opinion dimensions.
+Provides sentiment rollup weighted by engagement and relevance to video content.
+Includes a bias audit (HHI) to detect opinion concentration per demographic proxy group.
+
+**How it works:**
+1. Comments are fetched via YouTube Data API v3 (or yt-dlp if no API key is set)
+2. Each comment is classified for sentiment, emotion, political lean, and toxicity
+3. Relevance to the video's content is scored using sentence-transformers
+4. A weighted opinion score (O_D) is aggregated per dimension group
+5. An HHI bias audit flags dimensions where opinion is dominated by a single group
+
+**Disclaimer:** Gender, socioeconomic, and political inferences are probabilistic proxies
+derived from username patterns and text readability metrics — NOT identity labels.
+Nothing herein is financial advice.
+""",
+    allow_flagging="never",
+)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/fingpt/FinGPT_YouTubeAnalysis/classifiers.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/classifiers.py
@@ -1,0 +1,318 @@
+import math
+import logging
+from functools import lru_cache
+from typing import Optional
+
+import torch
+import textstat
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Minimum token count for reliable NLP inference
+MIN_TOKENS_FOR_NLP = 5
+# Max characters to pass to BERT-based models (approx 512 tokens)
+MAX_CHARS_FOR_BERT = 1800
+
+
+# ---------------------------------------------------------------------------
+# Model loader singletons (lazy, loaded on first call)
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _load_sentiment_model():
+    from transformers import pipeline as hf_pipeline
+    return hf_pipeline(
+        "text-classification",
+        model="cardiffnlp/twitter-roberta-base-sentiment",
+        return_all_scores=True,
+        truncation=True,
+        max_length=512,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_emotion_model():
+    from transformers import pipeline as hf_pipeline
+    return hf_pipeline(
+        "text-classification",
+        model="j-hartmann/emotion-english-distilroberta-base",
+        return_all_scores=False,
+        truncation=True,
+        max_length=512,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_political_model():
+    from transformers import pipeline as hf_pipeline
+    return hf_pipeline(
+        "text-classification",
+        model="bucketresearch/politicalBiasBERT",
+        return_all_scores=False,
+        truncation=True,
+        max_length=512,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_toxicity_model():
+    from transformers import pipeline as hf_pipeline
+    return hf_pipeline(
+        "text-classification",
+        model="unitary/toxic-bert",
+        return_all_scores=False,
+        truncation=True,
+        max_length=512,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_gender_detector():
+    import gender_guesser.detector as gd
+    return gd.Detector()
+
+
+# ---------------------------------------------------------------------------
+# Individual classifiers
+# ---------------------------------------------------------------------------
+
+def classify_sentiment(text: str) -> tuple[str, float]:
+    """
+    Returns (label, score) where label is in {positive, neutral, negative}
+    and score is linearly mapped to [-1, +1]:
+      score = P(positive) - P(negative)
+    """
+    model = _load_sentiment_model()
+    with torch.no_grad():
+        results = model(text[:MAX_CHARS_FOR_BERT])[0]
+
+    # results is a list of {label, score} dicts for all three classes
+    scores = {r["label"]: r["score"] for r in results}
+    # cardiffnlp labels: LABEL_0=negative, LABEL_1=neutral, LABEL_2=positive
+    p_pos = scores.get("LABEL_2", scores.get("positive", 0.0))
+    p_neg = scores.get("LABEL_0", scores.get("negative", 0.0))
+    scalar = p_pos - p_neg
+
+    if scalar > 0.1:
+        label = "positive"
+    elif scalar < -0.1:
+        label = "negative"
+    else:
+        label = "neutral"
+
+    return label, float(scalar)
+
+
+def classify_emotion(text: str) -> tuple[str, float]:
+    """
+    Returns (dominant_emotion_label, confidence_score).
+    Labels: joy, anger, fear, sadness, disgust, surprise, neutral.
+    """
+    model = _load_emotion_model()
+    with torch.no_grad():
+        result = model(text[:MAX_CHARS_FOR_BERT])[0]
+    return result["label"].lower(), float(result["score"])
+
+
+def classify_political_lean(text: str) -> tuple[str, float]:
+    """
+    Returns (label, score) where label is in {left, center, right}.
+    Returns ("unknown", 0.0) for texts that are too short.
+    """
+    tokens = text.split()
+    if len(tokens) < MIN_TOKENS_FOR_NLP:
+        return "unknown", 0.0
+
+    model = _load_political_model()
+    with torch.no_grad():
+        result = model(text[:MAX_CHARS_FOR_BERT])[0]
+    return result["label"].lower(), float(result["score"])
+
+
+def classify_toxicity(text: str) -> float:
+    """
+    Returns a float in [0, 1] representing toxicity probability.
+    """
+    model = _load_toxicity_model()
+    with torch.no_grad():
+        result = model(text[:MAX_CHARS_FOR_BERT])[0]
+    # unitary/toxic-bert outputs label "toxic" or "non-toxic"
+    if result["label"].lower() in ("toxic", "1"):
+        return float(result["score"])
+    return float(1.0 - result["score"])
+
+
+def infer_gender_proxy(author_name: str) -> str:
+    """
+    Use gender_guesser to infer gender from the first token of author_name.
+    Returns one of: "male", "female", "mostly_male", "mostly_female",
+    "andy" (androgynous), or "unknown".
+    Note: this is a probabilistic proxy, NOT an identity label.
+    """
+    if not author_name or not author_name.strip():
+        return "unknown"
+    detector = _load_gender_detector()
+    first_name = author_name.strip().split()[0]
+    result = detector.get_gender(first_name)
+    # gender_guesser returns: male, female, mostly_male, mostly_female, andy, unknown
+    return result if result != "unknown" else "unknown"
+
+
+def compute_edu_proxy(text: str) -> float:
+    """
+    Compute textstat.flesch_kincaid_grade(text).
+    Returns a float representing approximate grade level.
+    Labeled as an educational proxy, not a direct measure of education.
+    """
+    try:
+        grade = textstat.flesch_kincaid_grade(text)
+        # Clamp to reasonable range; textstat can return negative for very simple text
+        return float(max(0.0, min(grade, 20.0)))
+    except Exception:
+        return 0.0
+
+
+def compute_vocab_richness(text: str) -> float:
+    """
+    Compute type-token ratio: len(set(tokens)) / len(tokens).
+    Returns 0.0 for texts with fewer than 5 tokens.
+    """
+    tokens = text.lower().split()
+    if len(tokens) < 5:
+        return 0.0
+    return float(len(set(tokens)) / len(tokens))
+
+
+def compute_engagement_weight(likes: int, reply_count: int) -> float:
+    """
+    Return log(1 + likes + reply_count).
+    Uses math.log1p for numerical stability at zero.
+    """
+    return float(math.log1p(likes + reply_count))
+
+
+# ---------------------------------------------------------------------------
+# Batch entry point
+# ---------------------------------------------------------------------------
+
+def classify_comment(comment: dict) -> dict:
+    """
+    Run all classifiers on a single raw comment dict.
+    Merges derived fields into a copy of the input dict and returns it.
+    On per-classifier failure, fills that field with None/0.0/"unknown".
+
+    Input fields consumed: text, likes, reply_count, author
+    Derived fields added:
+      political_label, political_score,
+      sentiment_label, sentiment_score,
+      emotion_label, toxicity_score,
+      gender_proxy, edu_proxy, vocab_richness,
+      engagement_weight
+    """
+    result = dict(comment)
+    text = comment.get("text", "")
+    author = comment.get("author", "")
+    likes = int(comment.get("likes", 0))
+    reply_count = int(comment.get("reply_count", 0))
+
+    tokens = text.split()
+    is_short = len(tokens) < MIN_TOKENS_FOR_NLP
+
+    # Sentiment
+    try:
+        if is_short:
+            result["sentiment_label"] = "neutral"
+            result["sentiment_score"] = 0.0
+        else:
+            label, score = classify_sentiment(text)
+            result["sentiment_label"] = label
+            result["sentiment_score"] = score
+    except Exception as e:
+        logger.warning("Sentiment classification failed: %s", e)
+        result["sentiment_label"] = "neutral"
+        result["sentiment_score"] = 0.0
+
+    # Emotion
+    try:
+        if is_short:
+            result["emotion_label"] = "neutral"
+        else:
+            label, _ = classify_emotion(text)
+            result["emotion_label"] = label
+    except Exception as e:
+        logger.warning("Emotion classification failed: %s", e)
+        result["emotion_label"] = "neutral"
+
+    # Political lean
+    try:
+        label, score = classify_political_lean(text)
+        result["political_label"] = label
+        result["political_score"] = score
+    except Exception as e:
+        logger.warning("Political classification failed: %s", e)
+        result["political_label"] = "unknown"
+        result["political_score"] = 0.0
+
+    # Toxicity
+    try:
+        result["toxicity_score"] = classify_toxicity(text)
+    except Exception as e:
+        logger.warning("Toxicity classification failed: %s", e)
+        result["toxicity_score"] = 0.0
+
+    # Gender proxy
+    try:
+        result["gender_proxy"] = infer_gender_proxy(author)
+    except Exception as e:
+        logger.warning("Gender proxy inference failed: %s", e)
+        result["gender_proxy"] = "unknown"
+
+    # Education proxy and vocab richness (pure text stats, never fail hard)
+    result["edu_proxy"] = compute_edu_proxy(text)
+    result["vocab_richness"] = compute_vocab_richness(text)
+
+    # Engagement weight
+    result["engagement_weight"] = compute_engagement_weight(likes, reply_count)
+
+    return result
+
+
+def classify_batch(comments: list[dict], show_progress: bool = True) -> list[dict]:
+    """
+    Apply classify_comment to each item in comments.
+    Wraps iteration with tqdm when show_progress=True.
+    Returns a new list; does not mutate inputs.
+    """
+    from tqdm import tqdm
+
+    iterator = tqdm(comments, desc="Classifying comments") if show_progress else comments
+    results = []
+
+    for comment in iterator:
+        try:
+            results.append(classify_comment(comment))
+        except torch.cuda.OutOfMemoryError:
+            logger.warning("GPU OOM — clearing cache and retrying with single comment.")
+            torch.cuda.empty_cache()
+            try:
+                results.append(classify_comment(comment))
+            except Exception as e:
+                logger.error("Failed to classify comment after OOM retry: %s", e)
+                # Append comment with default/unknown fields
+                fallback = dict(comment)
+                fallback.update({
+                    "sentiment_label": "neutral", "sentiment_score": 0.0,
+                    "emotion_label": "neutral",
+                    "political_label": "unknown", "political_score": 0.0,
+                    "toxicity_score": 0.0,
+                    "gender_proxy": "unknown", "edu_proxy": 0.0,
+                    "vocab_richness": 0.0,
+                    "engagement_weight": compute_engagement_weight(
+                        int(comment.get("likes", 0)),
+                        int(comment.get("reply_count", 0)),
+                    ),
+                })
+                results.append(fallback)
+
+    return results

--- a/fingpt/FinGPT_YouTubeAnalysis/pipeline.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/pipeline.py
@@ -1,0 +1,188 @@
+import logging
+
+import numpy as np
+import pandas as pd
+
+from .scraper import fetch
+from .transcript import fetch_transcript, summarize_transcript_for_embedding
+from .classifiers import classify_batch
+from .relevance import (
+    compute_video_anchor,
+    score_relevance,
+    compute_echo_penalties,
+    encode_texts,
+)
+from .rollup import aggregate_all
+from .report import generate_report
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_COLUMNS = [
+    "text", "likes", "reply_count", "author", "published",
+    "sentiment_label", "sentiment_score",
+    "emotion_label",
+    "political_label", "political_score",
+    "toxicity_score",
+    "gender_proxy", "edu_proxy", "vocab_richness",
+    "engagement_weight",
+    "relevance", "echo_penalty",
+]
+
+
+def run_pipeline(
+    url: str,
+    max_comments: int = 500,
+    dimensions: list[str] = ("political", "socioeconomic", "gender", "emotion"),
+    output_format: str = "markdown",
+    prefer_api: bool = True,
+    include_bias_audit: bool = True,
+    relevance_threshold: float = 0.1,
+    embedding_model: str = "all-MiniLM-L6-v2",
+) -> tuple[str, pd.DataFrame]:
+    """
+    Full end-to-end pipeline.
+
+    Steps:
+      1. Fetch video metadata and raw comments (API or yt-dlp)
+      2. Fetch transcript (or None)
+      3. Classify comments with NLP models
+      4. Score relevance (cosine similarity to video anchor)
+      5. Compute echo penalties
+      6. Assemble full DataFrame
+      7. Aggregate and roll up by dimensions
+      8. Generate formatted report
+
+    Returns:
+        (report_string, full_annotated_dataframe)
+    """
+    # 1. Scrape
+    logger.info("Step 1/7: Fetching video data from %s", url)
+    video_metadata, raw_comments = fetch(url, max_comments=max_comments, prefer_api=prefer_api)
+    logger.info(
+        "Fetched metadata for '%s' and %d raw comments.",
+        video_metadata.get("title", ""), len(raw_comments),
+    )
+
+    if not raw_comments:
+        logger.warning("No comments found. Returning empty report.")
+        empty_df = pd.DataFrame(columns=_REQUIRED_COLUMNS)
+        report = generate_report(
+            {"global_opinion_score": 0.0, "rollups": {}, "comment_count": 0, "filtered_count": 0},
+            video_metadata,
+            fmt=output_format,
+            include_bias_audit=include_bias_audit,
+        )
+        return report, empty_df
+
+    # 2. Transcript (independent of classify_batch — can run before it)
+    logger.info("Step 2/7: Fetching video transcript.")
+    video_id = video_metadata.get("video_id", "")
+    transcript_text = fetch_transcript(video_id) if video_id else None
+    if transcript_text:
+        logger.info("Transcript fetched (%d chars).", len(transcript_text))
+    else:
+        logger.info("No transcript available; using title + description as anchor.")
+
+    # 3. Classify comments
+    logger.info("Step 3/7: Classifying %d comments.", len(raw_comments))
+    annotated_comments = classify_batch(raw_comments, show_progress=True)
+
+    # 4. Relevance scoring
+    logger.info("Step 4/7: Computing relevance scores.")
+    anchor_transcript = summarize_transcript_for_embedding(transcript_text) if transcript_text else None
+    video_anchor = compute_video_anchor(
+        anchor_transcript,
+        video_metadata.get("title", ""),
+        video_metadata.get("description", ""),
+        model_name=embedding_model,
+    )
+    comment_texts = [c.get("text", "") for c in annotated_comments]
+    relevance_scores = score_relevance(comment_texts, video_anchor, model_name=embedding_model)
+
+    # 5. Echo penalties
+    # Sort by engagement_weight descending before computing penalties
+    logger.info("Step 5/7: Computing echo penalties.")
+    comment_embeddings = encode_texts(comment_texts, model_name=embedding_model)
+    engagement_weights = np.array(
+        [c.get("engagement_weight", 0.0) for c in annotated_comments], dtype=float
+    )
+    sort_order = np.argsort(-engagement_weights)  # descending
+    sorted_embeddings = comment_embeddings[sort_order]
+    echo_penalties_sorted = compute_echo_penalties(sorted_embeddings)
+
+    # Map echo penalties back to original order
+    echo_penalties = np.empty(len(annotated_comments))
+    for sorted_idx, orig_idx in enumerate(sort_order):
+        echo_penalties[orig_idx] = echo_penalties_sorted[sorted_idx]
+
+    # 6. Assemble DataFrame
+    logger.info("Step 6/7: Assembling DataFrame.")
+    full_df = _assemble_dataframe(annotated_comments, relevance_scores, echo_penalties)
+
+    # 7. Aggregate
+    logger.info("Step 7/7: Aggregating results.")
+    aggregation_result = aggregate_all(full_df, relevance_threshold=relevance_threshold)
+
+    # Filter rollups to only requested dimensions
+    all_rollups = aggregation_result["rollups"]
+    filtered_rollups = {
+        dim: all_rollups[dim] for dim in dimensions if dim in all_rollups
+    }
+    aggregation_result["rollups"] = filtered_rollups
+
+    report = generate_report(
+        aggregation_result,
+        video_metadata,
+        fmt=output_format,
+        include_bias_audit=include_bias_audit,
+    )
+
+    logger.info(
+        "Pipeline complete. Global opinion score: %.4f over %d comments.",
+        aggregation_result["global_opinion_score"],
+        aggregation_result["comment_count"],
+    )
+
+    return report, full_df
+
+
+def _assemble_dataframe(
+    annotated_comments: list[dict],
+    relevance_scores: np.ndarray,
+    echo_penalties: np.ndarray,
+) -> pd.DataFrame:
+    """
+    Merge the annotated comment list and numpy arrays into a single DataFrame.
+    Validates that required columns are present; fills missing ones with defaults.
+    """
+    df = pd.DataFrame(annotated_comments)
+
+    df["relevance"] = relevance_scores
+    df["echo_penalty"] = echo_penalties
+
+    # Ensure all required columns exist
+    defaults = {
+        "text": "",
+        "likes": 0,
+        "reply_count": 0,
+        "author": "",
+        "published": "",
+        "sentiment_label": "neutral",
+        "sentiment_score": 0.0,
+        "emotion_label": "neutral",
+        "political_label": "unknown",
+        "political_score": 0.0,
+        "toxicity_score": 0.0,
+        "gender_proxy": "unknown",
+        "edu_proxy": 0.0,
+        "vocab_richness": 0.0,
+        "engagement_weight": 0.0,
+        "relevance": 0.5,
+        "echo_penalty": 0.0,
+    }
+    for col, default in defaults.items():
+        if col not in df.columns:
+            logger.warning("Column '%s' missing from DataFrame — filling with default.", col)
+            df[col] = default
+
+    return df

--- a/fingpt/FinGPT_YouTubeAnalysis/pipeline.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/pipeline.py
@@ -32,7 +32,7 @@ _REQUIRED_COLUMNS = [
 def run_pipeline(
     url: str,
     max_comments: int = 500,
-    dimensions: list[str] = ("political", "socioeconomic", "gender", "emotion"),
+    dimensions: list[str] = ["political", "socioeconomic", "gender", "emotion"],
     output_format: str = "markdown",
     prefer_api: bool = True,
     include_bias_audit: bool = True,

--- a/fingpt/FinGPT_YouTubeAnalysis/relevance.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/relevance.py
@@ -1,0 +1,111 @@
+import logging
+from functools import lru_cache
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "all-MiniLM-L6-v2"  # 22M params, fast, good quality
+
+
+@lru_cache(maxsize=4)
+def _load_embedding_model(model_name: str = DEFAULT_MODEL):
+    from sentence_transformers import SentenceTransformer
+    return SentenceTransformer(model_name)
+
+
+def encode_texts(texts: list[str], model_name: str = DEFAULT_MODEL) -> np.ndarray:
+    """
+    Encode a list of texts into unit-normalized embeddings.
+    Returns array of shape (N, embedding_dim).
+    Returns zero-row array for empty input.
+    """
+    if not texts:
+        model = _load_embedding_model(model_name)
+        return np.zeros((0, model.get_sentence_embedding_dimension()))
+
+    model = _load_embedding_model(model_name)
+    embeddings = model.encode(texts, normalize_embeddings=True, show_progress_bar=False)
+    return np.array(embeddings)
+
+
+def compute_video_anchor(
+    transcript_text: "str | None",
+    title: str,
+    description: str,
+    model_name: str = DEFAULT_MODEL,
+) -> np.ndarray:
+    """
+    Produce a single embedding for the video content.
+    If transcript_text is provided, uses first 512 chars of transcript.
+    Otherwise, encodes "{title}. {description[:300]}".
+    Returns array of shape (embedding_dim,).
+    """
+    if transcript_text:
+        anchor_text = transcript_text[:512]
+    else:
+        desc_snippet = (description or "")[:300]
+        anchor_text = f"{title}. {desc_snippet}".strip(". ")
+
+    if not anchor_text:
+        # Absolute fallback: return zero vector
+        model = _load_embedding_model(model_name)
+        dim = model.get_sentence_embedding_dimension()
+        logger.warning("No video content available for anchor; using zero vector.")
+        return np.zeros(dim)
+
+    embeddings = encode_texts([anchor_text], model_name=model_name)
+    return embeddings[0]
+
+
+def score_relevance(
+    comment_texts: list[str],
+    video_anchor: np.ndarray,
+    model_name: str = DEFAULT_MODEL,
+) -> np.ndarray:
+    """
+    Compute cosine similarity between each comment embedding and video_anchor.
+    Returns array of shape (N,) with values clipped to [0, 1].
+    Negative cosine similarity is treated as zero relevance.
+    """
+    if not comment_texts:
+        return np.zeros(0)
+
+    comment_embeddings = encode_texts(comment_texts, model_name=model_name)
+
+    # Both are unit-normalized, so dot product = cosine similarity
+    anchor_norm = video_anchor / (np.linalg.norm(video_anchor) + 1e-10)
+    similarities = comment_embeddings @ anchor_norm
+    return np.clip(similarities, 0.0, 1.0)
+
+
+def compute_echo_penalties(
+    comment_embeddings: np.ndarray,
+    window: int = 50,
+) -> np.ndarray:
+    """
+    For each comment i, compute the mean cosine similarity to the
+    min(window, i) most recently processed comments.
+    Comments should be pre-sorted by descending engagement_weight (caller's responsibility).
+
+    Returns array of shape (N,) with values in [0, 1].
+    First comment gets penalty 0.0 (no prior context yet).
+    High penalty = comment is semantically similar to recent top comments
+                   (likely bot spam or brigading).
+    """
+    n = len(comment_embeddings)
+    if n == 0:
+        return np.zeros(0)
+
+    penalties = np.zeros(n)
+
+    for i in range(1, n):
+        start = max(0, i - window)
+        prior = comment_embeddings[start:i]  # shape (k, dim)
+        current = comment_embeddings[i]       # shape (dim,)
+
+        # Both sets are already unit-normalized from encode_texts
+        sims = prior @ current  # shape (k,)
+        penalties[i] = float(np.mean(np.clip(sims, 0.0, 1.0)))
+
+    return penalties

--- a/fingpt/FinGPT_YouTubeAnalysis/relevance.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/relevance.py
@@ -30,7 +30,7 @@ def encode_texts(texts: list[str], model_name: str = DEFAULT_MODEL) -> np.ndarra
 
 
 def compute_video_anchor(
-    transcript_text: "str | None",
+    transcript_text: str | None,
     title: str,
     description: str,
     model_name: str = DEFAULT_MODEL,

--- a/fingpt/FinGPT_YouTubeAnalysis/report.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/report.py
@@ -1,0 +1,265 @@
+import io
+import json
+import logging
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+OutputFormat = Literal["json", "csv", "markdown"]
+
+HHI_DOMINANCE_THRESHOLD = 0.6
+
+PROXY_DISCLAIMER = (
+    "IMPORTANT: Gender, socioeconomic, and political inferences in this report "
+    "are probabilistic proxies derived from username patterns and text readability "
+    "metrics. They are NOT identity labels and carry significant uncertainty. "
+    "These dimensions are provided for analytical balance auditing only."
+)
+
+
+def compute_hhi(group_scores: pd.Series) -> float:
+    """
+    Compute the Herfindahl-Hirschman Index over opinion scores.
+
+    HHI = sum((|s_i| / sum(|s_i|))^2) for each group i
+    Normalized by dividing by the maximum possible HHI (= 1/N for N equal groups).
+
+    Interpretation:
+        HHI near 0: opinion is evenly distributed across groups
+        HHI near 1: opinion is dominated by a single group
+    Returns 0.0 if all scores are zero.
+    """
+    scores = group_scores.dropna().to_numpy(dtype=float)
+    abs_scores = np.abs(scores)
+    total = abs_scores.sum()
+
+    if total == 0.0 or len(scores) == 0:
+        return 0.0
+
+    shares = abs_scores / total
+    raw_hhi = float(np.sum(shares ** 2))
+
+    n = len(scores)
+    # Normalize: max HHI when one group has everything = 1.0
+    # Min HHI when all groups equal = 1/N
+    # Normalize to [0, 1] by: (raw - 1/N) / (1 - 1/N)
+    min_hhi = 1.0 / n
+    if n == 1:
+        return 1.0
+
+    normalized = (raw_hhi - min_hhi) / (1.0 - min_hhi)
+    return float(np.clip(normalized, 0.0, 1.0))
+
+
+def bias_audit(rollups: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    """
+    Compute HHI for each dimension's rollup table.
+    Returns a DataFrame with columns:
+        dimension, hhi, n_groups, dominant_group, dominant_score
+    """
+    rows = []
+    for dimension, rollup_df in rollups.items():
+        if rollup_df.empty:
+            continue
+
+        hhi = compute_hhi(rollup_df["opinion_score"])
+
+        dominant_idx = rollup_df["opinion_score"].abs().idxmax()
+        dominant_group = rollup_df.loc[dominant_idx, "group_label"]
+        dominant_score = float(rollup_df.loc[dominant_idx, "opinion_score"])
+
+        rows.append({
+            "dimension": dimension,
+            "hhi": round(hhi, 4),
+            "n_groups": len(rollup_df),
+            "dominant_group": dominant_group,
+            "dominant_score": round(dominant_score, 4),
+        })
+
+    return pd.DataFrame(rows, columns=[
+        "dimension", "hhi", "n_groups", "dominant_group", "dominant_score"
+    ])
+
+
+def format_rollup_table(
+    rollup_df: pd.DataFrame,
+    fmt: OutputFormat = "markdown",
+) -> str:
+    """
+    Format a single dimension's rollup DataFrame as the requested format.
+    """
+    if rollup_df.empty:
+        return "(no data)"
+
+    display_df = rollup_df.copy()
+    for col in ("opinion_score", "avg_engagement", "avg_relevance", "avg_toxicity"):
+        if col in display_df.columns:
+            display_df[col] = display_df[col].round(4)
+
+    if fmt == "json":
+        return display_df.to_json(orient="records", indent=2)
+
+    if fmt == "csv":
+        buf = io.StringIO()
+        display_df.to_csv(buf, index=False)
+        return buf.getvalue()
+
+    # markdown (default)
+    return display_df.to_markdown(index=False)
+
+
+def _interpret_score(score: float) -> str:
+    """Convert a numeric O_D score to a plain-language interpretation."""
+    if score > 0.5:
+        return "strongly positive"
+    if score > 0.15:
+        return "moderately positive"
+    if score > -0.15:
+        return "neutral / mixed"
+    if score > -0.5:
+        return "moderately negative"
+    return "strongly negative"
+
+
+def generate_report(
+    aggregation_result: dict,
+    video_metadata: dict,
+    fmt: OutputFormat = "markdown",
+    include_bias_audit: bool = True,
+) -> str:
+    """
+    Top-level report generator.
+
+    Assembles:
+      - Video metadata header
+      - Global opinion score with plain-language interpretation
+      - Per-dimension rollup tables
+      - Bias audit section (if include_bias_audit=True)
+      - Disclaimer footer
+
+    Returns a single formatted string.
+    """
+    global_score = aggregation_result.get("global_opinion_score", 0.0)
+    rollups = aggregation_result.get("rollups", {})
+    comment_count = aggregation_result.get("comment_count", 0)
+    filtered_count = aggregation_result.get("filtered_count", 0)
+
+    title = video_metadata.get("title", "Unknown Title")
+    channel = video_metadata.get("channel_title", "Unknown Channel")
+    view_count = video_metadata.get("view_count", 0)
+    published = video_metadata.get("published_at", "")
+
+    lines = []
+
+    if fmt == "markdown":
+        lines.append(f"# FinGPT YouTube Comment Analysis Report\n")
+        lines.append(f"## Video Information\n")
+        lines.append(f"- **Title:** {title}")
+        lines.append(f"- **Channel:** {channel}")
+        if published:
+            lines.append(f"- **Published:** {published[:10]}")
+        lines.append(f"- **Views:** {view_count:,}")
+        lines.append(f"- **Comments analyzed:** {comment_count}")
+        if filtered_count > 0:
+            lines.append(f"- **Comments filtered (low relevance):** {filtered_count}")
+        lines.append("")
+
+        lines.append(f"## Global Opinion Score\n")
+        lines.append(f"**Score:** `{global_score:.4f}` — *{_interpret_score(global_score)}*")
+        lines.append("")
+        lines.append(
+            "> Score range: −1 (strongly negative) to +1 (strongly positive). "
+            "Weighted by engagement, relevance to video content, and echo-chamber penalty."
+        )
+        lines.append("")
+
+        if rollups:
+            lines.append("## Opinion by Dimension\n")
+            for dimension, rollup_df in rollups.items():
+                lines.append(f"### {dimension.capitalize()}\n")
+                lines.append(format_rollup_table(rollup_df, fmt=fmt))
+                lines.append("")
+
+        if include_bias_audit and rollups:
+            audit_df = bias_audit(rollups)
+            lines.append("## Bias Audit (Herfindahl-Hirschman Index)\n")
+            lines.append(
+                "HHI measures concentration of opinion. "
+                f"Values above {HHI_DOMINANCE_THRESHOLD} indicate opinion dominated by a single group — interpret with caution.\n"
+            )
+            lines.append(format_rollup_table(audit_df, fmt=fmt))
+
+            dominated = audit_df[audit_df["hhi"] > HHI_DOMINANCE_THRESHOLD]
+            if not dominated.empty:
+                lines.append("")
+                lines.append("**Concentration warnings:**")
+                for _, row in dominated.iterrows():
+                    lines.append(
+                        f"- ⚠ `{row['dimension']}`: HHI={row['hhi']:.3f} — "
+                        f"opinion dominated by group **{row['dominant_group']}** "
+                        f"(score={row['dominant_score']:.4f})"
+                    )
+            lines.append("")
+
+        lines.append("---")
+        lines.append(f"*{PROXY_DISCLAIMER}*")
+        lines.append("")
+        lines.append(
+            "*Nothing herein is financial advice. Results reflect comment-section "
+            "sentiment only and may not represent the broader population.*"
+        )
+
+    elif fmt == "json":
+        report_dict = {
+            "video": {
+                "title": title,
+                "channel": channel,
+                "published_at": published,
+                "view_count": view_count,
+            },
+            "analysis": {
+                "comment_count": comment_count,
+                "filtered_count": filtered_count,
+                "global_opinion_score": round(global_score, 4),
+                "interpretation": _interpret_score(global_score),
+            },
+            "rollups": {
+                dim: json.loads(format_rollup_table(df, fmt="json"))
+                for dim, df in rollups.items()
+            },
+            "disclaimer": PROXY_DISCLAIMER,
+        }
+        if include_bias_audit and rollups:
+            audit_df = bias_audit(rollups)
+            report_dict["bias_audit"] = json.loads(
+                format_rollup_table(audit_df, fmt="json")
+            )
+        return json.dumps(report_dict, indent=2)
+
+    elif fmt == "csv":
+        # For CSV, produce a simple multi-section text
+        sections = [
+            "# FinGPT YouTube Comment Analysis Report",
+            f"title,{title}",
+            f"channel,{channel}",
+            f"view_count,{view_count}",
+            f"comment_count,{comment_count}",
+            f"global_opinion_score,{global_score:.4f}",
+            f"interpretation,{_interpret_score(global_score)}",
+            "",
+        ]
+        for dim, rollup_df in rollups.items():
+            sections.append(f"# {dim}")
+            sections.append(format_rollup_table(rollup_df, fmt="csv"))
+
+        if include_bias_audit and rollups:
+            sections.append("# bias_audit")
+            sections.append(format_rollup_table(bias_audit(rollups), fmt="csv"))
+
+        sections.append(f"# disclaimer\n{PROXY_DISCLAIMER}")
+        return "\n".join(sections)
+
+    return "\n".join(lines)

--- a/fingpt/FinGPT_YouTubeAnalysis/requirements.txt
+++ b/fingpt/FinGPT_YouTubeAnalysis/requirements.txt
@@ -1,0 +1,14 @@
+google-api-python-client>=2.100.0
+youtube-transcript-api>=0.6.1
+yt-dlp>=2023.10.13
+transformers>=4.35.0
+sentence-transformers>=2.2.2
+torch>=2.0.1
+gender-guesser>=0.4.0
+textstat>=0.7.3
+pandas>=2.1.0
+numpy>=1.26.0
+scikit-learn>=1.3.1
+gradio>=4.0.0
+python-dotenv>=1.0.0
+tqdm>=4.66.0

--- a/fingpt/FinGPT_YouTubeAnalysis/rollup.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/rollup.py
@@ -1,0 +1,144 @@
+import logging
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+DimensionType = Literal["political", "socioeconomic", "gender", "emotion", "all"]
+
+RELEVANCE_THRESHOLD = 0.1
+
+_DIMENSION_COLUMN_MAP = {
+    "political": "political_label",
+    "gender": "gender_proxy",
+    "emotion": "emotion_label",
+}
+
+
+def compute_opinion_score(df: pd.DataFrame) -> float:
+    """
+    Compute the global O_D score over all comments in df.
+
+    Formula:
+        numerator   = sum(w_i * s_i * r_i / max(echo_penalty_i, 1e-6))
+        denominator = sum(w_i * r_i)
+        O_D         = numerator / denominator
+
+    Returns 0.0 if denominator is zero (all comments have relevance = 0).
+    """
+    if df.empty:
+        return 0.0
+
+    w = df["engagement_weight"].to_numpy(dtype=float)
+    s = df["sentiment_score"].to_numpy(dtype=float)
+    r = df["relevance"].to_numpy(dtype=float)
+    echo = np.maximum(df["echo_penalty"].to_numpy(dtype=float), 1e-6)
+
+    numerator = np.sum(w * s * r / echo)
+    denominator = np.sum(w * r)
+
+    if denominator == 0.0:
+        logger.warning("Denominator is zero in compute_opinion_score (all relevance = 0).")
+        return 0.0
+
+    return float(numerator / denominator)
+
+
+def _assign_edu_quartile(df: pd.DataFrame) -> pd.Series:
+    """
+    Bin df["edu_proxy"] into Q1/Q2/Q3/Q4 quartile labels.
+    Returns a Series of group label strings ("Q1", "Q2", "Q3", "Q4").
+    Falls back to "Q1" for all rows if all values are identical.
+    """
+    try:
+        return pd.qcut(df["edu_proxy"], q=4, labels=["Q1", "Q2", "Q3", "Q4"]).astype(str)
+    except ValueError:
+        # All values identical — cannot form 4 quantile bins
+        return pd.Series(["Q1"] * len(df), index=df.index)
+
+
+def rollup_by_dimension(
+    df: pd.DataFrame,
+    dimension: DimensionType,
+) -> pd.DataFrame:
+    """
+    Group df by the label column for the given dimension and compute
+    O_D for each group.
+
+    Returns a DataFrame with columns:
+        dimension, group_label, opinion_score, comment_count,
+        avg_engagement, avg_relevance, avg_toxicity
+    """
+    if dimension == "all":
+        frames = [
+            rollup_by_dimension(df, d)
+            for d in ("political", "socioeconomic", "gender", "emotion")
+        ]
+        return pd.concat(frames, ignore_index=True)
+
+    df = df.copy()
+
+    if dimension == "socioeconomic":
+        df["_group"] = _assign_edu_quartile(df)
+    else:
+        col = _DIMENSION_COLUMN_MAP[dimension]
+        df["_group"] = df[col].fillna("unknown").astype(str)
+
+    rows = []
+    for group_label, group_df in df.groupby("_group"):
+        rows.append({
+            "dimension": dimension,
+            "group_label": str(group_label),
+            "opinion_score": compute_opinion_score(group_df),
+            "comment_count": len(group_df),
+            "avg_engagement": float(group_df["engagement_weight"].mean()),
+            "avg_relevance": float(group_df["relevance"].mean()),
+            "avg_toxicity": float(group_df["toxicity_score"].mean()),
+        })
+
+    return pd.DataFrame(rows, columns=[
+        "dimension", "group_label", "opinion_score",
+        "comment_count", "avg_engagement", "avg_relevance", "avg_toxicity",
+    ])
+
+
+def aggregate_all(
+    df: pd.DataFrame,
+    relevance_threshold: float = RELEVANCE_THRESHOLD,
+) -> dict:
+    """
+    Compute:
+      1. Global O_D score
+      2. Rollup tables for all four dimensions
+      3. Counts of total vs. filtered comments
+
+    Returns a dict with keys:
+        "global_opinion_score": float,
+        "rollups": dict[str, pd.DataFrame],  # keyed by dimension name
+        "comment_count": int,
+        "filtered_count": int  # comments with relevance < threshold
+    """
+    total_count = len(df)
+    relevant_df = df[df["relevance"] >= relevance_threshold].copy()
+    filtered_count = total_count - len(relevant_df)
+
+    if filtered_count > 0:
+        logger.info(
+            "Filtered %d / %d comments with relevance < %.2f",
+            filtered_count, total_count, relevance_threshold,
+        )
+
+    global_score = compute_opinion_score(relevant_df)
+
+    rollups = {}
+    for dimension in ("political", "socioeconomic", "gender", "emotion"):
+        rollups[dimension] = rollup_by_dimension(relevant_df, dimension)
+
+    return {
+        "global_opinion_score": global_score,
+        "rollups": rollups,
+        "comment_count": len(relevant_df),
+        "filtered_count": filtered_count,
+    }

--- a/fingpt/FinGPT_YouTubeAnalysis/scraper.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/scraper.py
@@ -1,0 +1,271 @@
+import os
+import re
+import time
+import logging
+from typing import Optional
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
+
+
+class QuotaExceededError(Exception):
+    """Raised when the YouTube Data API daily quota is exhausted."""
+
+
+def build_youtube_client():
+    """
+    Build and return an authenticated googleapiclient.discovery Resource object.
+    Raises EnvironmentError if YOUTUBE_API_KEY is not set.
+    """
+    if not YOUTUBE_API_KEY:
+        raise EnvironmentError(
+            "YOUTUBE_API_KEY is not set. Add it to your .env file or set it as an "
+            "environment variable. Alternatively, set prefer_api=False to use yt-dlp."
+        )
+    from googleapiclient.discovery import build
+    return build("youtube", "v3", developerKey=YOUTUBE_API_KEY)
+
+
+def extract_video_id(url: str) -> str:
+    """
+    Parse a YouTube URL and return the 11-character video ID.
+    Handles youtu.be short links, /watch?v=, /embed/, and /shorts/ formats.
+    Raises ValueError if the ID cannot be parsed.
+    """
+    patterns = [
+        r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/shorts/)([A-Za-z0-9_-]{11})",
+        r"youtube\.com/v/([A-Za-z0-9_-]{11})",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    raise ValueError(f"Could not extract YouTube video ID from URL: {url}")
+
+
+def fetch_video_metadata_api(video_id: str, client) -> dict:
+    """
+    Retrieve video metadata via videos().list().
+    Returns a dict with keys: video_id, title, description,
+    channel_title, published_at, view_count, like_count, comment_count.
+    """
+    response = client.videos().list(
+        part="snippet,statistics",
+        id=video_id
+    ).execute()
+
+    if not response.get("items"):
+        raise ValueError(f"Video not found or unavailable: {video_id}")
+
+    item = response["items"][0]
+    snippet = item["snippet"]
+    stats = item.get("statistics", {})
+
+    return {
+        "video_id": video_id,
+        "title": snippet.get("title", ""),
+        "description": snippet.get("description", ""),
+        "channel_title": snippet.get("channelTitle", ""),
+        "published_at": snippet.get("publishedAt", ""),
+        "view_count": int(stats.get("viewCount", 0)),
+        "like_count": int(stats.get("likeCount", 0)),
+        "comment_count": int(stats.get("commentCount", 0)),
+    }
+
+
+def fetch_comments_api(
+    video_id: str,
+    client,
+    max_comments: int = 500,
+    order: str = "relevance",
+    rate_limit_pause: float = 0.5,
+) -> list[dict]:
+    """
+    Paginate through commentThreads().list() results.
+    Returns list of dicts with: text, likes, reply_count, author, published.
+    Handles quota exhaustion and uses exponential backoff on 429/500 errors.
+    """
+    from googleapiclient.errors import HttpError
+
+    comments = []
+    page_token = None
+    retries = 0
+    max_retries = 4
+
+    while len(comments) < max_comments:
+        try:
+            kwargs = dict(
+                part="snippet",
+                videoId=video_id,
+                maxResults=min(100, max_comments - len(comments)),
+                order=order,
+                textFormat="plainText",
+            )
+            if page_token:
+                kwargs["pageToken"] = page_token
+
+            response = client.commentThreads().list(**kwargs).execute()
+            retries = 0  # reset on success
+
+        except HttpError as e:
+            status = e.resp.status
+            if status == 403:
+                error_reason = ""
+                try:
+                    import json as _json
+                    details = _json.loads(e.content)
+                    reasons = [
+                        err.get("reason", "")
+                        for err in details.get("error", {}).get("errors", [])
+                    ]
+                    error_reason = ",".join(reasons)
+                except Exception:
+                    pass
+
+                if "commentsDisabled" in error_reason or "disabled" in error_reason.lower():
+                    logger.warning("Comments are disabled for video %s", video_id)
+                    return comments
+                if "quotaExceeded" in error_reason or "dailyLimitExceeded" in error_reason:
+                    raise QuotaExceededError(
+                        "YouTube Data API daily quota exhausted. "
+                        "Try again tomorrow or use prefer_api=False for yt-dlp fallback."
+                    )
+                raise ValueError(
+                    f"Video {video_id} is private, unlisted, or access was denied (HTTP 403)."
+                )
+            elif status in (429, 500, 503):
+                retries += 1
+                if retries > max_retries:
+                    raise
+                wait = 2 ** retries
+                logger.warning("HTTP %d — retrying in %ds (attempt %d/%d)", status, wait, retries, max_retries)
+                time.sleep(wait)
+                continue
+            else:
+                raise
+
+        for item in response.get("items", []):
+            top = item["snippet"]["topLevelComment"]["snippet"]
+            comments.append({
+                "text": top.get("textDisplay", ""),
+                "likes": int(top.get("likeCount", 0)),
+                "reply_count": int(item["snippet"].get("totalReplyCount", 0)),
+                "author": top.get("authorDisplayName", ""),
+                "published": top.get("publishedAt", ""),
+            })
+            if len(comments) >= max_comments:
+                break
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+        time.sleep(rate_limit_pause)
+
+    return comments
+
+
+def fetch_video_metadata_ytdlp(url: str) -> dict:
+    """
+    Use yt_dlp.YoutubeDL to extract video info without an API key.
+    Returns the same schema as fetch_video_metadata_api.
+    """
+    import yt_dlp
+
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "extract_flat": False,
+        "skip_download": True,
+    }
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        try:
+            info = ydl.extract_info(url, download=False)
+        except yt_dlp.utils.DownloadError as e:
+            raise ValueError(f"Video is private, unavailable, or URL is invalid: {e}")
+
+    return {
+        "video_id": info.get("id", ""),
+        "title": info.get("title", ""),
+        "description": info.get("description", ""),
+        "channel_title": info.get("uploader", ""),
+        "published_at": info.get("upload_date", ""),
+        "view_count": int(info.get("view_count") or 0),
+        "like_count": int(info.get("like_count") or 0),
+        "comment_count": int(info.get("comment_count") or 0),
+    }
+
+
+def fetch_comments_ytdlp(url: str, max_comments: int = 500) -> list[dict]:
+    """
+    Use yt_dlp.YoutubeDL with getcomments=True to pull comments.
+    Maps yt-dlp comment fields to the canonical schema fields.
+    """
+    import yt_dlp
+
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "getcomments": True,
+        "extractor_args": {"youtube": {"max_comments": [str(max_comments)]}},
+    }
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        try:
+            info = ydl.extract_info(url, download=False)
+        except yt_dlp.utils.DownloadError as e:
+            raise ValueError(f"Video is private, unavailable, or URL is invalid: {e}")
+
+    raw_comments = info.get("comments") or []
+    comments = []
+    for c in raw_comments[:max_comments]:
+        # yt-dlp comments can be nested; only take top-level (parent == None or "root")
+        if c.get("parent") not in (None, "root"):
+            continue
+        comments.append({
+            "text": c.get("text", ""),
+            "likes": int(c.get("like_count") or 0),
+            "reply_count": int(c.get("reply_count") or 0),
+            "author": c.get("author", ""),
+            "published": c.get("timestamp", ""),
+        })
+        if len(comments) >= max_comments:
+            break
+
+    return comments
+
+
+def fetch(
+    url: str,
+    max_comments: int = 500,
+    prefer_api: bool = True,
+) -> tuple[dict, list[dict]]:
+    """
+    Primary entry point called by pipeline.py.
+    Returns (video_metadata_dict, list_of_raw_comment_dicts).
+    Falls back to yt-dlp if prefer_api=False or no API key is available.
+    """
+    use_api = prefer_api and bool(YOUTUBE_API_KEY)
+
+    if use_api:
+        try:
+            client = build_youtube_client()
+            video_id = extract_video_id(url)
+            metadata = fetch_video_metadata_api(video_id, client)
+            comments = fetch_comments_api(video_id, client, max_comments=max_comments)
+            return metadata, comments
+        except QuotaExceededError:
+            logger.warning(
+                "YouTube API quota exceeded — falling back to yt-dlp (no API key used)."
+            )
+        except Exception as e:
+            logger.warning("YouTube API fetch failed (%s) — falling back to yt-dlp.", e)
+
+    logger.info("Using yt-dlp to fetch video data (no API key required).")
+    metadata = fetch_video_metadata_ytdlp(url)
+    comments = fetch_comments_ytdlp(url, max_comments=max_comments)
+    return metadata, comments

--- a/fingpt/FinGPT_YouTubeAnalysis/transcript.py
+++ b/fingpt/FinGPT_YouTubeAnalysis/transcript.py
@@ -1,0 +1,108 @@
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_transcript(
+    video_id: str,
+    preferred_languages: tuple[str, ...] = ("en",),
+) -> Optional[str]:
+    """
+    Attempt to fetch the transcript in order of preferred_languages,
+    then fall back to auto-generated English captions.
+    Returns the full concatenated text as a single string,
+    or None if no transcript is available.
+    """
+    from youtube_transcript_api import (
+        YouTubeTranscriptApi,
+        TranscriptsDisabled,
+        NoTranscriptFound,
+    )
+
+    for attempt in range(2):
+        try:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+
+            # Try preferred languages first (manual captions)
+            for lang in preferred_languages:
+                try:
+                    transcript = transcript_list.find_transcript([lang])
+                    logger.info(
+                        "Using manual transcript in '%s' for video %s", lang, video_id
+                    )
+                    segments = transcript.fetch()
+                    return " ".join(seg["text"] for seg in segments)
+                except NoTranscriptFound:
+                    continue
+
+            # Fall back to auto-generated English
+            try:
+                transcript = transcript_list.find_generated_transcript(list(preferred_languages) + ["en"])
+                logger.info(
+                    "Using auto-generated transcript for video %s (lower quality)", video_id
+                )
+                segments = transcript.fetch()
+                return " ".join(seg["text"] for seg in segments)
+            except NoTranscriptFound:
+                pass
+
+            logger.warning("No transcript found for video %s in any language.", video_id)
+            return None
+
+        except TranscriptsDisabled:
+            logger.warning("Transcripts are disabled for video %s.", video_id)
+            return None
+        except Exception as e:
+            if attempt == 0:
+                logger.warning(
+                    "Transcript fetch failed (%s) — retrying in 5s.", e
+                )
+                time.sleep(5)
+            else:
+                logger.warning("Transcript fetch failed after retry: %s", e)
+                return None
+
+    return None
+
+
+def chunk_transcript(
+    transcript_text: str,
+    max_chars: int = 2000,
+) -> list[str]:
+    """
+    Split the transcript into overlapping chunks.
+    Overlap is 10% of max_chars to preserve sentence context across boundaries.
+    Returns a list of chunk strings.
+    """
+    if not transcript_text:
+        return []
+
+    overlap = max_chars // 10
+    chunks = []
+    start = 0
+    text_len = len(transcript_text)
+
+    while start < text_len:
+        end = min(start + max_chars, text_len)
+        chunks.append(transcript_text[start:end])
+        if end == text_len:
+            break
+        start = end - overlap
+
+    return chunks
+
+
+def summarize_transcript_for_embedding(
+    transcript_text: str,
+    max_chars: int = 512,
+) -> str:
+    """
+    Truncate transcript_text to max_chars for use as a sentence-transformer input.
+    Takes the first max_chars characters, which captures the intro context that
+    comments most often reference.
+    """
+    if not transcript_text:
+        return ""
+    return transcript_text[:max_chars]


### PR DESCRIPTION
Implements fingpt/FinGPT_YouTubeAnalysis/ with full end-to-end pipeline:

- scraper.py: YouTube Data API v3 with yt-dlp keyless fallback, handles
  pagination, quota exhaustion, private videos, and disabled comments
- transcript.py: caption/transcript extraction via youtube-transcript-api
  with language fallback and transcript chunking utilities
- classifiers.py: lazy-loaded HuggingFace classifiers (sentiment via
  cardiffnlp/twitter-roberta-base-sentiment, emotion via j-hartmann/
  emotion-english-distilroberta-base, political lean via bucketresearch/
  politicalBiasBERT, toxicity via unitary/toxic-bert) plus gender proxy
  (gender-guesser), edu proxy (textstat Flesch-Kincaid), vocab richness,
  and engagement weight
- relevance.py: sentence-transformer (all-MiniLM-L6-v2) cosine similarity
  scoring against video anchor and O(N*window) echo-chamber penalty
- rollup.py: weighted O_D aggregation equation rollup across political,
  socioeconomic (edu quartile), gender, and emotion dimensions
- report.py: multi-format output (markdown/json/csv) with HHI bias audit
  that flags dimensions where opinion is concentrated in a single group
- pipeline.py: orchestrator wiring all steps with clear logging
- app.py: Gradio UI mirroring FinGPT_Forecaster/app.py pattern

https://claude.ai/code/session_01MTbhy94HVi8xoqze58hPdQ